### PR TITLE
Delete ending zerobyte from password.

### DIFF
--- a/kcpass.py
+++ b/kcpass.py
@@ -46,6 +46,6 @@ while i < len(kcpasswd):
   r = charkch ^ charmh
   pwd += chr(r)
   if r == 0:
-    print '\n\tThe password is: "{}".\n'.format(pwd)
+    print '\n\tThe password is: "{}".\n'.format(pwd.rstrip('\0'))
     break
   i += 2

--- a/kcpass.py
+++ b/kcpass.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -21,13 +21,13 @@ magic_static='7d895223d2bcddeaa3b91f'
 pwd = ''
 
 if len(sys.argv) != 2:
-  print 'Please write as a first argv the hexadecimal kcpassword value:'
-  print 'Example: python {} 1ceb3147d2172f1140ff63bf'.format(sys.argv[0])
+  print( 'Please write as a first argv the hexadecimal kcpassword value:' )
+  print( 'Example: python {} 1ceb3147d2172f1140ff63bf'.format(sys.argv[0]) )
   exit(1)
 
 kcpasswd=sys.argv[1]
-print u'\n\tKcpasswd: 0x{}.'.format(kcpasswd)
-print u'\tMagic Xor: 0x{}.'.format(magic_static)
+print( '\n\tKcpasswd: 0x{}.'.format(kcpasswd) )
+print( '\tMagic Xor: 0x{}.'.format(magic_static) )
 
 tam_xor = len(magic_static)
 tam = len(kcpasswd) - tam_xor
@@ -35,7 +35,7 @@ magic = magic_static
 while tam > 0:
   tam -= tam_xor
   magic += magic_static
-print u'\tUsed Magic Xor: 0x{}.'.format(magic)
+print( '\tUsed Magic Xor: 0x{}.'.format(magic) )
 
 i = 0
 while i < len(kcpasswd):
@@ -46,6 +46,8 @@ while i < len(kcpasswd):
   r = charkch ^ charmh
   pwd += chr(r)
   if r == 0:
-    print '\n\tThe password is: "{}".\n'.format(pwd.rstrip('\0'))
+    print( '\n\tThe password is: "{}".\n'.format(pwd.rstrip('\0')) )
     break
   i += 2
+
+exit(0)

--- a/kcpass.py
+++ b/kcpass.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
If you redirect the output into a textfile, there will be a final zerobyte "\0" in the password which can be confusing when output from other applications.
The usage of the method rstrip fix this.
